### PR TITLE
personal stack init

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Setup file system
         run: |
           make setup_filesystem
-          ls
+          echo 
         env:
           POLICYENGINE_DB_PASSWORD: ${{ secrets.POLICYENGINE_DB_PASSWORD }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GCP_SA_KEY }}
@@ -114,7 +114,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: us-central1-docker.pkg.dev/policyengine-infrastructure/policyengine-api/policyengine-api-image:${{ github.run_number }}
+          tags: |
+            us-central1-docker.pkg.dev/policyengine-infrastructure/policyengine-api/policyengine-api-image:${{ github.run_number }}
+            us-central1-docker.pkg.dev/policyengine-infrastructure/policyengine-api/policyengine-api-image:latest
       - name: Pull to verify
         run: docker pull us-central1-docker.pkg.dev/policyengine-infrastructure/policyengine-api/policyengine-api-image:${{ github.run_number }}
       - name: Post Job Steps (Always)


### PR DESCRIPTION
- Formatting
- Logging: Added entry/exit logs in endpoint/search
- Config: Reduced worker count to 4 to avoid Github asset download rate limit
- Logging: Added logs for metadata fetch response
- Build: Added docker build and push, disabled app deploy
- Auth Setup: Set up auth and push image to artifact registry
- Bug fix: Add quotes to echo
- Bug fix: Removed docker auth
- Logging: Add ls post file_system build
- Bug fix: Moved cleanup to end
- Logging: Pull image
- Bugfix: Set push to true for docker build stage
- Bugfix: Added to y to gCloud auth
- Bugfix: Added .git to .dockerignore
- Infra: Added latest tag to policyengine-api-image
