### PR TITLE
personal stack init

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -117,8 +117,8 @@ jobs:
           tags: |
             us-central1-docker.pkg.dev/policyengine-infrastructure/policyengine-api/policyengine-api-image:${{ github.run_number }}
             us-central1-docker.pkg.dev/policyengine-infrastructure/policyengine-api/policyengine-api-image:latest
-      - name: Pull to verify
-        run: docker pull us-central1-docker.pkg.dev/policyengine-infrastructure/policyengine-api/policyengine-api-image:${{ github.run_number }}
+      # - name: Pull to verify
+      #   run: docker pull us-central1-docker.pkg.dev/policyengine-infrastructure/policyengine-api/policyengine-api-image:${{ github.run_number }}
       - name: Post Job Steps (Always)
         if: always()
         run: make cleanup

--- a/gcp/policyengine_api/Dockerfile
+++ b/gcp/policyengine_api/Dockerfile
@@ -5,4 +5,5 @@ ENV POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN .github_microdata_token
 ENV OPENAI_API_KEY .openai_api_key
 ADD . /app
 RUN cd /app && make install && make test
+RUN chmod +x start.sh
 CMD ./start.sh


### PR DESCRIPTION
- Formatting
- Logging: Added entry/exit logs in endpoint/search
- Config: Reduced worker count to 4 to avoid Github asset download rate limit
- Logging: Added logs for metadata fetch response
- Build: Added docker build and push, disabled app deploy
- Auth Setup: Set up auth and push image to artifact registry
- Bug fix: Add quotes to echo
- Bug fix: Removed docker auth
- Logging: Add ls post file_system build
- Bug fix: Moved cleanup to end
- Logging: Pull image
- Bugfix: Set push to true for docker build stage
- Bugfix: Added to y to gCloud auth
- Bugfix: Added .git to .dockerignore
- Infra: Added latest tag to policyengine-api-image
- Bigfix: X Permission for start.sh
- Chore: Disabled Pull to verify step
