### PR TITLE
personal stack init

### DIFF
--- a/gcp/policyengine_api/start.sh
+++ b/gcp/policyengine_api/start.sh
@@ -1,5 +1,6 @@
 # Start the API
 gunicorn -b :$PORT policyengine_api.api --timeout 300 --workers 4 &
+echo "Running on PORT:$PORT"
 # Start the redis server
 redis-server &
 # Start the worker


### PR DESCRIPTION
- Formatting
- Logging: Added entry/exit logs in endpoint/search
- Config: Reduced worker count to 4 to avoid Github asset download rate limit
- Logging: Added logs for metadata fetch response
- Build: Added docker build and push, disabled app deploy
- Auth Setup: Set up auth and push image to artifact registry
- Bug fix: Add quotes to echo
- Bug fix: Removed docker auth
- Logging: Add ls post file_system build
- Bug fix: Moved cleanup to end
- Logging: Pull image
- Bugfix: Set push to true for docker build stage
- Bugfix: Added to y to gCloud auth
- Bugfix: Added .git to .dockerignore
- Infra: Added latest tag to policyengine-api-image
- Bigfix: X Permission for start.sh
- Chore: Disabled Pull to verify step
- Logging: Added port logging to gunicorn
