### PR TITLE
personal stack init

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -113,6 +113,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: ./compute_engine_Dockerfile
           push: true
           tags: |
             us-central1-docker.pkg.dev/policyengine-infrastructure/policyengine-api/policyengine-api-image:${{ github.run_number }}

--- a/gcp/policyengine_api/compute_engine_Dockerfile
+++ b/gcp/policyengine_api/compute_engine_Dockerfile
@@ -1,0 +1,10 @@
+FROM nikhilwoodruff/policyengine-api:latest
+ENV GOOGLE_APPLICATION_CREDENTIALS .gac.json
+ENV POLICYENGINE_DB_PASSWORD .dbpw
+ENV POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN .github_microdata_token
+ENV OPENAI_API_KEY .openai_api_key
+ENV PORT 80
+ADD . /app
+RUN cd /app && make install && make test
+RUN chmod +x start.sh
+CMD ./start.sh


### PR DESCRIPTION
- Formatting
- Logging: Added entry/exit logs in endpoint/search
- Config: Reduced worker count to 4 to avoid Github asset download rate limit
- Logging: Added logs for metadata fetch response
- Build: Added docker build and push, disabled app deploy
- Auth Setup: Set up auth and push image to artifact registry
- Bug fix: Add quotes to echo
- Bug fix: Removed docker auth
- Logging: Add ls post file_system build
- Bug fix: Moved cleanup to end
- Logging: Pull image
- Bugfix: Set push to true for docker build stage
- Bugfix: Added to y to gCloud auth
- Bugfix: Added .git to .dockerignore
- Infra: Added latest tag to policyengine-api-image
- Bigfix: X Permission for start.sh
- Chore: Disabled Pull to verify step
- Logging: Added port logging to gunicorn
- Chore: Created separate dockerfile for compute engine
